### PR TITLE
Providing API method as argument - issue #44

### DIFF
--- a/rlgraph/graphs/graph_builder.py
+++ b/rlgraph/graphs/graph_builder.py
@@ -848,6 +848,10 @@ class GraphBuilder(Specifiable):
                                                                api_method_call[2] is not None else None
                 api_method_call = api_method_call[0]
 
+            if callable(api_method_call):
+                # Allow passing the function directly
+                api_method_call = api_method_call.__name__
+
             if api_method_call not in self.api:
                 raise RLGraphError("No API-method with name '{}' found!".format(api_method_call))
 

--- a/rlgraph/tests/core/test_api_methods.py
+++ b/rlgraph/tests/core/test_api_methods.py
@@ -185,6 +185,12 @@ class TestAPIMethods(unittest.TestCase):
         test = ComponentTest(component=container, input_spaces=dict(input_=float))
         test.test(("test", 1.23), expected_outputs=len(sub_comps) * (1.23 + 1), decimals=2)
 
+    def test_providing_method_as_argument(self):
+        component = DummyWithVar()
+        test = ComponentTest(component=component, input_spaces=dict(input_=float))
+
+        test.test((component.run_plus, 1.23456), expected_outputs=3.23456, decimals=5)
+        test.test((component.run_minus, 1.23456), expected_outputs=-0.7654, decimals=4)
 
     #def test_kwargs_in_api_call(self):
     #    core = Component(scope="container")


### PR DESCRIPTION
This change adds support for providing the method to be called directly
to the GraphExecutor.execute in addition to the method's name as string