### PR TITLE
Add Custom Bitflip Environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ agent = DQNAgent.from_file(
 
 # Get an action, take a step, observe reward.
 state = environment.reset()
-preprocessed_state, action = agent.get_action(
+action, preprocessed_state = agent.get_action(
   states=state,
   extra_returns="preprocessed_states"
 )

--- a/contrib/bitflip_env/Bitflip_README.md
+++ b/contrib/bitflip_env/Bitflip_README.md
@@ -1,0 +1,10 @@
+#BitFlip Environment
+
+
+BitFlip is a custom environment that was used in HER paper https://arxiv.org/abs/1707.01495
+
+BitFlip is an environment with the state space S = {0, 1}^n
+and action space {A = 0 <= i <= n - 1} where n >= 0 and i refers to flipping the *i*th bit in the state space.
+When i = n the environment process one step without flipping any bits.
+Every environment has a goal state *g*, where *g* is sampled from the possible states. 
+The reward function is defined such that policy receive 0 if the s = g, -1 otherwise.

--- a/contrib/bitflip_env/rlgraph/environments/__init__.py
+++ b/contrib/bitflip_env/rlgraph/environments/__init__.py
@@ -1,0 +1,57 @@
+# Copyright 2018 The RLgraph authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from rlgraph.environments.environment import Environment
+from rlgraph.environments.deterministic_env import DeterministicEnv
+from rlgraph.environments.grid_world import GridWorld
+from rlgraph.environments.openai_gym import OpenAIGymEnv
+from rlgraph.environments.random_env import RandomEnv
+from rlgraph.environments.vector_env import VectorEnv
+from rlgraph.environments.sequential_vector_env import SequentialVectorEnv
+import contrib.bitflip_env.rlgraph.environments.custom.openai.envs
+
+Environment.__lookup_classes__ = dict(
+    deterministic=DeterministicEnv,
+    deterministicenv=DeterministicEnv,
+    gridworld=GridWorld,
+    openai=OpenAIGymEnv,
+    openaigymenv=OpenAIGymEnv,
+    openaigym=OpenAIGymEnv,
+    randomenv=RandomEnv,
+    random=RandomEnv,
+    sequentialvector=SequentialVectorEnv,
+    sequentialvectorenv=SequentialVectorEnv
+)
+
+try:
+    import deepmind_lab
+
+    # If import works: Can import our Adapter.
+    from rlgraph.environments.deepmind_lab import DeepmindLabEnv
+
+    Environment.__lookup_classes__.update(dict(
+        deepmindlab=DeepmindLabEnv,
+        deepmindlabenv=DeepmindLabEnv,
+    ))
+    # TODO travis error on this, investigate.
+except Exception:
+    pass
+
+__all__ = ["Environment"] + \
+          list(set(map(lambda x: x.__name__, Environment.__lookup_classes__.values())))

--- a/contrib/bitflip_env/rlgraph/environments/custom/openai/__init__.py
+++ b/contrib/bitflip_env/rlgraph/environments/custom/openai/__init__.py
@@ -1,0 +1,8 @@
+from gym.envs.registration import register
+
+register(
+    id='bitflip-v0',
+    entry_point='contrib.bitflip_env.rlgraph.environments.custom.openai.envs:BitFlip',
+    max_episode_steps=200,
+    reward_threshold=195.0,
+)

--- a/contrib/bitflip_env/rlgraph/environments/custom/openai/envs/__init__.py
+++ b/contrib/bitflip_env/rlgraph/environments/custom/openai/envs/__init__.py
@@ -1,0 +1,1 @@
+from contrib.bitflip_env.rlgraph.environments.custom.openai.envs.bit_flip import BitFlip

--- a/contrib/bitflip_env/rlgraph/environments/custom/openai/envs/bit_flip.py
+++ b/contrib/bitflip_env/rlgraph/environments/custom/openai/envs/bit_flip.py
@@ -1,0 +1,91 @@
+import gym
+import numpy as np
+from gym import spaces
+from gym.utils import seeding
+
+
+class BitFlip(gym.GoalEnv):
+    """
+    A multi-goal environment based on BitFlip environment from [1]
+
+     [1] Hindsight Experience Replay - https://arxiv.org/abs/1707.01495
+    TODO add support for mean = zero
+    """
+
+    def __init__(self, bit_length=16, max_steps=None):
+
+        super(BitFlip, self).__init__()
+
+        assert bit_length >= 1, 'bit_length must be >= 1, found {}'.format(bit_length)
+
+        self.bit_length = bit_length
+
+        if max_steps is None:
+            self.max_steps = bit_length
+        else:
+            self.max_steps = max_steps
+
+        self.last_action = -1  # -1 for reset
+        self.steps = 0
+        self.seed()
+        self.action_space = spaces.Discrete(bit_length + 1)  # index = n means to not flip any bit
+        # achieved goal and observation are identical in bit_flip environment, however it is made this way to be
+        # compatible with Openai GoalEnv
+        self.observation_space = spaces.Dict(dict(
+            observation=spaces.Box(low=0, high=1, shape=(bit_length,), dtype=np.int32),
+            achieved_goal=spaces.Box(low=0, high=1, shape=(bit_length,), dtype=np.int32),
+            desired_goal=spaces.Box(low=0, high=1, shape=(bit_length,), dtype=np.int32),
+        ))
+
+        self.reset()
+
+    def step(self, action):
+        obs = self._get_obs()
+
+        if not action == self.bit_length:  # ignore moves that do flip
+            self._bitflip(action)
+
+        self.last_action = action
+        self.steps += 1
+
+        reward = self.compute_reward(obs['achieved_goal'], obs['desired_goal'], {})
+        done = self._terminate()
+        info = {}  # TODO add useful debug information in info
+
+        return obs, reward, done, info
+
+    def render(self, mode='human'):
+        print("Observation_space: {}, last_action: {}, num_steps: {}".format(self._get_obs(),
+                                                                             self.last_action,
+                                                                             self.steps))
+
+    def compute_reward(self, achieved_goal, desired_goal, info):
+        return 0 if np.array_equal(achieved_goal, desired_goal) else -1
+
+    def seed(self, seed=None):
+        self.np_random, seed = seeding.np_random(seed)
+        return [seed]
+
+    def _terminate(self):
+        return np.array_equal(self.state, self.goal) or self.steps >= self.max_steps
+
+    def reset(self):
+        self.steps = 0
+        self.last_action = -1  # -1 for reset
+
+        initial_state = self.observation_space.sample()
+
+        self.state = initial_state['observation']
+        self.goal = initial_state['desired_goal']
+
+        return self._get_obs()
+
+    def _get_obs(self):
+        return {
+            'observation': self.state.copy(),
+            'achieved_goal': self.state.copy(),
+            'desired_goal': self.goal.copy(),
+        }
+
+    def _bitflip(self, index):
+        self.state[index] = not self.state[index]

--- a/contrib/bitflip_env/rlgraph/examples/configs/random_bitflip.json
+++ b/contrib/bitflip_env/rlgraph/examples/configs/random_bitflip.json
@@ -1,0 +1,5 @@
+{
+  "type": "random-agent",
+  "network_spec": {},
+  "preprocessing_spec": []
+}

--- a/contrib/bitflip_env/rlgraph/examples/random_bitflip.py
+++ b/contrib/bitflip_env/rlgraph/examples/random_bitflip.py
@@ -1,0 +1,90 @@
+# Copyright 2018 The RLgraph authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Example script for training a DQN agent on an OpenAI gym environment.
+
+Usage:
+
+python dqn_cartpole.py [--config configs/dqn_cartpole.json] [--env CartPole-v0]
+
+```
+# Run script
+python dqn_cartpole.py
+```
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+from absl import flags
+
+from rlgraph.agents import Agent
+from contrib.bitflip_env.rlgraph.environments import OpenAIGymEnv
+from rlgraph.execution import SingleThreadedWorker
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('config', './configs/random_bitflip.json', 'Agent config file.')
+flags.DEFINE_string('env', 'bitflip-v0', 'gym environment ID.')
+flags.DEFINE_boolean('render', True, 'Render the environment.')
+flags.DEFINE_integer('episodes', 200, 'Number of training episodes.')
+
+
+def main(argv):
+    try:
+        FLAGS(argv)
+    except flags.Error as e:
+        print('%s\\nUsage: %s ARGS\\n%s' % (e, sys.argv[0], FLAGS))
+
+    agent_config_path = os.path.join(os.getcwd(), FLAGS.config)
+    with open(agent_config_path, 'rt') as fp:
+        agent_config = json.load(fp)
+
+    env = OpenAIGymEnv.from_spec({
+        "type": "openai",
+        "gym_env": FLAGS.env
+    })
+
+    agent = Agent.from_spec(
+        agent_config,
+        state_space=env.state_space,
+        action_space=env.action_space
+    )
+
+    rewards = []
+
+    def episode_finished_callback(reward, duration, timesteps, **kwargs):
+        rewards.append(reward)
+        if len(rewards) % 10 == 0:
+            print("Episode {} finished: reward={:.2f}, average reward={:.2f}.".format(
+                len(rewards), reward, np.mean(rewards[-10:])
+            ))
+
+    worker = SingleThreadedWorker(env_spec=lambda: env, agent=agent, render=FLAGS.render,
+                                  worker_executes_preprocessing=False,
+                                  episode_finish_callback=episode_finished_callback)
+    print("Starting workload, this will take some time for the agents to build.")
+    results = worker.execute_episodes(FLAGS.episodes)
+
+    print("Mean reward: {:.2f} / over the last 10 episodes: {:.2f}".format(
+        np.mean(rewards), np.mean(rewards[-10:])
+    ))
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/contrib/bitflip_env/rlgraph/tests/environments/test_openai_gym_atari.py
+++ b/contrib/bitflip_env/rlgraph/tests/environments/test_openai_gym_atari.py
@@ -1,0 +1,72 @@
+# Copyright 2018 The RLgraph authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import unittest
+
+from contrib.bitflip_env.rlgraph.environments import OpenAIGymEnv
+
+
+class TestOpenAIAtariEnv(unittest.TestCase):
+    """
+    Tests creation, resetting and stepping through an openAI Atari Env.
+    """
+    def test_openai_atari_env(self):
+        env = OpenAIGymEnv("Pong-v0")
+
+        # Simple test runs with fixed actions.
+        s = env.reset()
+        # Assert we have pixels.
+        self.assertGreaterEqual(np.mean(s), 0)
+        self.assertLessEqual(np.mean(s), 255)
+        accum_reward = 0.0
+        for _ in range(100):
+            s, r, t, _ = env.step(env.action_space.sample())
+            assert isinstance(r, np.ndarray)
+            assert r.dtype == np.float32
+            assert isinstance(t, bool)
+            self.assertGreaterEqual(np.mean(s), 0)
+            self.assertLessEqual(np.mean(s), 255)
+            accum_reward += r
+
+        print("Accumulated Reward: {}".format(accum_reward))
+
+        env.terminate()
+
+    def test_openai_bitflip_env(self):
+        env = OpenAIGymEnv("bitflip-v0")
+
+        # Simple test runs with fixed actions.
+        s = env.reset()
+        # Assert we have pixels.
+        self.assertGreaterEqual(np.mean(s), 0)
+        self.assertLessEqual(np.mean(s), 255)
+        accum_reward = 0.0
+        for _ in range(100):
+            s, r, t, _ = env.step(env.action_space.sample())
+            assert isinstance(r, np.ndarray)
+            assert r.dtype == np.float32
+            assert isinstance(t, bool)
+            self.assertGreaterEqual(np.mean(s), 0)
+            self.assertLessEqual(np.mean(s), 255)
+            accum_reward += r
+
+        print("Accumulated Reward: {}".format(accum_reward))
+
+        env.terminate()

--- a/rlgraph/agents/agent.py
+++ b/rlgraph/agents/agent.py
@@ -40,6 +40,7 @@ class Agent(Specifiable):
     """
     Generic agent defining RLGraph-API operations and parses and sanitizes configuration specs.
     """
+
     def __init__(self, state_space, action_space, discount=0.98,
                  preprocessing_spec=None, network_spec=None, internal_states_space=None,
                  policy_spec=None, value_function_spec=None,
@@ -122,7 +123,7 @@ class Agent(Specifiable):
 
         # Construct the Policy network.
         policy_spec = policy_spec or dict()
-        if network_spec is not None:
+        if "network_spec" not in policy_spec:
             policy_spec["network_spec"] = network_spec
         if "action_space" not in policy_spec:
             policy_spec["action_space"] = self.action_space
@@ -162,11 +163,11 @@ class Agent(Specifiable):
                 return []
             return tuple([[] for _ in range(i)])
 
-        self.states_buffer = defaultdict(list)  #partial(fact_, len(self.flat_state_space)))
+        self.states_buffer = defaultdict(list)  # partial(fact_, len(self.flat_state_space)))
         self.actions_buffer = defaultdict(partial(factory_, len(self.flat_action_space or [])))
         self.internals_buffer = defaultdict(list)
         self.rewards_buffer = defaultdict(list)
-        self.next_states_buffer = defaultdict(list)  #partial(fact_, len(self.flat_state_space)))
+        self.next_states_buffer = defaultdict(list)  # partial(fact_, len(self.flat_state_space)))
         self.terminals_buffer = defaultdict(list)
 
         self.observe_spec = parse_observe_spec(observe_spec)
@@ -212,7 +213,7 @@ class Agent(Specifiable):
         if env_id is None:
             env_id = self.default_env
         del self.states_buffer[env_id]  # = ([] for _ in range(len(self.flat_state_space)))
-        del self.actions_buffer[env_id]   # = ([] for _ in range(len(self.flat_action_space)))
+        del self.actions_buffer[env_id]  # = ([] for _ in range(len(self.flat_action_space)))
         del self.internals_buffer[env_id]  # = []
         del self.rewards_buffer[env_id]  # = []
         del self.next_states_buffer[env_id]  # = ([] for _ in range(len(self.flat_state_space)))
@@ -285,7 +286,7 @@ class Agent(Specifiable):
         """
         if build_options is not None:
             self.build_options.update(build_options)
-        assert not self.graph_built,\
+        assert not self.graph_built, \
             "ERROR: Attempting to build agent which has already been built. Ensure auto_build parameter is set to " \
             "False (was {}), and method has not been called twice".format(self.auto_build)
 

--- a/rlgraph/agents/dqfd_agent.py
+++ b/rlgraph/agents/dqfd_agent.py
@@ -166,7 +166,7 @@ class DQFDAgent(Agent):
         def action_from_preprocessed_state(root, preprocessed_states, time_step=0, use_exploration=True):
             sample_deterministic = agent.policy.get_deterministic_action(preprocessed_states)
             actions = agent.exploration.get_action(sample_deterministic["action"], time_step, use_exploration)
-            return preprocessed_states, actions
+            return actions, preprocessed_states
 
         # State (from environment) to action with preprocessing.
         @rlgraph_api(component=self.root_component)
@@ -329,11 +329,10 @@ class DQFDAgent(Agent):
         self.timesteps += batch_size
 
         # Control, which return value to "pull" (depending on `additional_returns`).
-        return_ops = [1, 0] if "preprocessed_states" in extra_returns else [1]
+        return_ops = [0, 1] if "preprocessed_states" in extra_returns else [0]  # 1=preprocessed_states, 0=action
         ret = self.graph_executor.execute((
             call_method,
             [batched_states, self.timesteps, use_exploration],
-            # 0=preprocessed_states, 1=action
             return_ops
         ))
         if remove_batch_rank:

--- a/rlgraph/agents/dqn_agent.py
+++ b/rlgraph/agents/dqn_agent.py
@@ -167,7 +167,7 @@ class DQNAgent(Agent):
         def action_from_preprocessed_state(root, preprocessed_states, time_step=0, use_exploration=True):
             sample_deterministic = agent.policy.get_deterministic_action(preprocessed_states)
             actions = agent.exploration.get_action(sample_deterministic["action"], time_step, use_exploration)
-            return preprocessed_states, actions
+            return actions, preprocessed_states
 
         # State (from environment) to action with preprocessing.
         @rlgraph_api(component=self.root_component)
@@ -319,11 +319,10 @@ class DQNAgent(Agent):
         self.timesteps += batch_size
 
         # Control, which return value to "pull" (depending on `additional_returns`).
-        return_ops = [1, 0] if "preprocessed_states" in extra_returns else [1]
+        return_ops = [0, 1] if "preprocessed_states" in extra_returns else [0]  # 1=preprocessed_states, 0=action
         ret = self.graph_executor.execute((
             call_method,
             [batched_states, self.timesteps, use_exploration],
-            # 0=preprocessed_states, 1=action
             return_ops
         ))  #, flip_batch_with_dict_keys=isinstance(self.action_space, ContainerSpace))
         if remove_batch_rank:

--- a/rlgraph/execution/single_threaded_worker.py
+++ b/rlgraph/execution/single_threaded_worker.py
@@ -217,7 +217,7 @@ class SingleThreadedWorker(Worker):
                 )
                 preprocessed_states = np.array(self.preprocessed_states_buffer)
             else:
-                preprocessed_states, actions = self.agent.get_action(
+                actions, preprocessed_states = self.agent.get_action(
                     states=np.array(env_states), use_exploration=use_exploration,
                     apply_preprocessing=True, extra_returns="preprocessed_states"
                 )

--- a/rlgraph/tests/environments/test_readme_example.py
+++ b/rlgraph/tests/environments/test_readme_example.py
@@ -26,6 +26,7 @@ class TestReadmeExample(unittest.TestCase):
     """
     Tests if the readme example runs.
     """
+
     def test_readme_example(self):
         """
         Tests deterministic functionality of RandomEnv.
@@ -46,7 +47,7 @@ class TestReadmeExample(unittest.TestCase):
 
         # Get an action, take a step, observe reward.
         state = environment.reset()
-        preprocessed_state, action = agent.get_action(
+        action, preprocessed_state = agent.get_action(
             states=state,
             extra_returns="preprocessed_states"
         )


### PR DESCRIPTION
Addition into the contrib directory:
* New custom environment based on a discrete multi-goal environment, bitflip from hindsight experience replay[[1]](https://arxiv.org/abs/1707.01495 ) 

N.b. I opted to use int32 to represent the environment states, boolean can be used (by simply changing the box-type from int32 to bool) however the int can offer better flexibility in making the environment as complex as needed.

Bug Fix into the main directory:
* Single threaded worker executor with a preprocess state is taking the action in the wrong order.
get_action() from agent class returns the preprocessed states as optional second argument.
* Readme example, DQN, Actor-critic, DQfD and PPO return order of get_action is reversed of what Agent class suggests as well as what is intuitive. 
* Agent attempts to create a policy from a policy spec even if no policy spec is passed, I have alerted it to at least call with an empty dictionary and not crash if no policy_spec is provided. 

Follow-up: Would having a new object Action, that contains an optional pre_processed state, be preferable to relying on returning a tuple in the right order?
